### PR TITLE
Add basic tests for apps

### DIFF
--- a/ecodata/app/apps/subsetter_app.py
+++ b/ecodata/app/apps/subsetter_app.py
@@ -174,7 +174,7 @@ class Subsetter(param.Parameterized):
         elif self.option_picker.value == "track_points":
             args["track_points"] = self.tracks_file.value
             args["boundary_type"] = self.boundary_type_tracks.value
-            args["buffer"] = self.buffer.valuex
+            args["buffer"] = self.buffer.value
 
         elif self.option_picker.value == "bounding_geom":
             args["bounding_geom"] = self.bounding_geom_file.value

--- a/ecodata/app/apps/subsetter_app.py
+++ b/ecodata/app/apps/subsetter_app.py
@@ -174,7 +174,7 @@ class Subsetter(param.Parameterized):
         elif self.option_picker.value == "track_points":
             args["track_points"] = self.tracks_file.value
             args["boundary_type"] = self.boundary_type_tracks.value
-            args["buffer"] = self.buffer.value
+            args["buffer"] = self.buffer.valuex
 
         elif self.option_picker.value == "bounding_geom":
             args["bounding_geom"] = self.bounding_geom_file.value

--- a/ecodata/tests/conftest.py
+++ b/ecodata/tests/conftest.py
@@ -6,6 +6,10 @@ import pytest
 
 import ecodata
 from ecodata.app.apps import applications
+from ecodata.app.apps.tracks_explorer_app import TracksExplorer
+from ecodata.app.apps.gridded_data_explorer_app import GriddedDataExplorer
+from ecodata.app.apps.subsetter_app import Subsetter
+
 
 PORT = [6000]
 
@@ -56,3 +60,19 @@ def make_test_frame_dirs(install_test_data):
     shutil.copytree(test_frames_dir, test_frames_dir_weird, dirs_exist_ok=True)
 
     return test_frames_dir_weird
+
+
+
+@pytest.fixture
+def track_explorer():
+    return TracksExplorer()
+
+
+@pytest.fixture
+def gridded_data_explorer():
+    return GriddedDataExplorer()
+
+
+@pytest.fixture
+def subsetter():
+    return Subsetter()

--- a/ecodata/tests/test_apps.py
+++ b/ecodata/tests/test_apps.py
@@ -1,7 +1,14 @@
+import shutil
+from pathlib import Path
 from sys import platform
 
 import pytest
 import requests
+
+import geopandas as gpd
+import panel as pn
+import xarray as xr
+from ecodata.tests.conftest import test_data_dir
 
 
 @pytest.mark.skipif(platform == "linux" or platform == "linux2", reason="needs update")
@@ -12,3 +19,44 @@ def test_server_has_every_app(serve_apps, port, apps):
 
 
 # TODO you could add tests using playwright to doing ui browser testing?
+
+
+def test_track_explorer_load_data(install_test_data, track_explorer):
+    track_explorer.tracksfile.value = str(test_data_dir / "public_caribou_tracks.csv")
+    track_explorer.load_data()
+
+    assert track_explorer.tracks is not None
+    assert isinstance(track_explorer.tracks, gpd.GeoDataFrame)
+
+    # check plot was created
+    assert track_explorer.plot_pane.object is not None
+
+
+def test_gridded_data_explorer_load_data(install_test_data, gridded_data_explorer):
+    gridded_data_explorer.filein.value = str(test_data_dir / "NASA_public_caribou.nc")
+    gridded_data_explorer.load_data()
+
+    assert gridded_data_explorer.ds_raw is not None
+    assert gridded_data_explorer.ds is not None
+    assert isinstance(gridded_data_explorer.ds_raw, xr.Dataset)
+    assert isinstance(gridded_data_explorer.ds, xr.Dataset)
+
+    # check plot was created
+    # assert track_explorer.plot_pane.object is not None
+
+
+def test_subsetter_load_data(install_test_data, subsetter, tmp_path):
+    subsetter.input_file.value = str(test_data_dir / "public_caribou_roads")
+    subsetter.output_file.value = str(tmp_path / "output_file")
+    subsetter.option_picker.value = "bounding_geom"
+    subsetter.bounding_geom_file.value = str(test_data_dir / "public_caribou_tracks_extent.geojson")
+    subsetter.boundary_type_geom.value = "rectangular"
+
+    subsetter.create_subset()
+
+    assert subsetter.view is not None
+    assert subsetter.view[subsetter.view_objects["plot"]].object != "## Create a subset!"
+    assert isinstance(subsetter.view[subsetter.view_objects["plot"]], pn.pane.Matplotlib)
+
+    # check plot was created
+    # assert track_explorer.plot_pane.object is not None


### PR DESCRIPTION
Add tests for subsetter, gridded_data_explorer, and track_explorer where the app is instantiated, given a data path, loaded and checked if the correct data container was loaded and in certain instances make sure a plot is loaded