### PR TITLE
Update ci_conda_constructor.yml to upload binaries to release on workflow dispatch

### DIFF
--- a/.github/workflows/ci_conda_constructor.yml
+++ b/.github/workflows/ci_conda_constructor.yml
@@ -1,8 +1,10 @@
 name: conda_constructor
 on:
-  push:
-    # tags:
-    #   - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag of Release'
+        required: true
 
 jobs:
     unixlike:
@@ -61,6 +63,15 @@ jobs:
                     path: scripts/ecodata*
                     name: ecodata-${{ matrix.OS_NAME }}
 
+            -   name: Upload binaries to release
+                uses: svenstaro/upload-release-action@v2
+                with:
+                    repo_token: ${{ secrets.GITHUB_TOKEN }}
+                    file: scripts/ecodata*
+                    tag: ${{ inputs.tag }}
+                    overwrite: true
+                    file_glob: true
+
     windows:
         runs-on: windows-latest
         steps:
@@ -89,3 +100,12 @@ jobs:
               with:
                 path: scripts/ecodata*
                 name: ecodata-Windows
+
+            -   name: Upload binaries to release
+                uses: svenstaro/upload-release-action@v2
+                with:
+                    repo_token: ${{ secrets.GITHUB_TOKEN }}
+                    file: scripts/ecodata*
+                    tag: ${{ inputs.tag }}
+                    overwrite: true
+                    file_glob: true


### PR DESCRIPTION
[Update ci_conda_constructor.yml to upload binaries to release on workflow_dispatch](https://github.com/jemissik/ecodata/commit/cc9371272011047d88c4fe19174804dac44f8191)

This will allow us to run the conda constructor on demand, and then it will upload the artifact to the release of a specific tag that we supply as an input.